### PR TITLE
added device reccomender so it's not just "cuda", can be "mps"

### DIFF
--- a/app.py
+++ b/app.py
@@ -191,8 +191,8 @@ def main():
                     gen_components = [
                         gr.components.Checkbox(label="Use Autocast", value=True),
                         gr.components.Number(label="Crop Offset", value=0),
-                        gr.components.Radio(device_list, label="Device Accelerator", value=device_str),
-                        gr.components.Radio(device_list, label="Device Offload", value=device_str),
+                        gr.components.Radio(device_list, label="Device Accelerator", value=recc_device),
+                        gr.components.Radio(device_list, label="Device Offload", value=recc_device),
                         gr.components.Number(label="Sample Rate", value=48000),
                         gr.components.Number(label="Chunk Size", value=65536),
                         gr.components.Number(label="Seed", value=-1),


### PR DESCRIPTION
Note that this still fails to fully execute on Mac due to a problem with the `sample_diffusion` backend: the device is defaulting to 'cpu' if it can't find 'cuda' 👎 : recommend using `aeiou.core.get_device()` ,which for this demo I created a special version, `get_recc_device()`. 

Error from sample diffusion reads.   
```python
  File "/Users/shawley/github/Sample-Diffusion-Gradio/sample_diffusion/dance_diffusion/dd/inference.py", line 43, in generate
    x_T = torch.randn([batch_size, 2, self.model.chunk_size], generator=self.generator, device=self.device_accelerator)
RuntimeError: Expected a 'mps' device type for generator but found 'cpu'
```
I can check that later.  At least this gradio seems to work fine! ;-) 
You may not want to merge this just yet; up to you. 